### PR TITLE
Fixed e2e - cypress testing bug.

### DIFF
--- a/cypress/integration/login_spec.js
+++ b/cypress/integration/login_spec.js
@@ -2,8 +2,8 @@ describe("Should test login form.", () => {
   it("Should successfuly login in to the application", () => {
     //login
     cy.visit("/login");
-    cy.findByRole("textbox").type("merima123@test.com");
-    cy.findByPlaceholderText(/password/i).type("merima123");
+    cy.findByRole("textbox").type("john.doe0.1721878087822739@gmail.com");
+    cy.findByPlaceholderText(/password/i).type("testing");
     cy.findByRole("button", {
       name: /login/i,
     }).click();

--- a/cypress/integration/posts_spec.js
+++ b/cypress/integration/posts_spec.js
@@ -3,8 +3,8 @@ describe("Should test posts.", () => {
     //user needs to log in. after user gets log in, user will be able to visit post details.
 
     cy.visit("/login");
-    cy.findByRole("textbox").type("merima123@test.com");
-    cy.findByPlaceholderText(/password/i).type("merima123");
+    cy.findByRole("textbox").type("john.doe0.1721878087822739@gmail.com");
+    cy.findByPlaceholderText(/password/i).type("testing");
     cy.findByRole("button", {
       name: /login/i,
     }).click();
@@ -15,6 +15,6 @@ describe("Should test posts.", () => {
     //user clicks on image, so to navigate on post details page.
     cy.get('[data-test="data-test-post-details-image"]').eq(1).click();
 
-    cy.url().should("include", "/post"); // => true
+    cy.url().should("include", "/post");
   });
 });

--- a/cypress/integration/registration_spec.js
+++ b/cypress/integration/registration_spec.js
@@ -4,11 +4,11 @@ describe("Should test registration.", () => {
     cy.visit("/");
     cy.findByPlaceholderText(/first name/i).type("John");
     cy.findByPlaceholderText(/last name/i).type("Doee");
-    cy.findByPlaceholderText(/email/i).type("merima123@test.com");
-    cy.findByPlaceholderText(/password/i).type("merima123");
+    cy.findByPlaceholderText(/email/i).type(
+      `john.doe${Math.random()}@gmail.com`
+    );
+    cy.findByPlaceholderText(/password/i).type("testing");
 
-    cy.findByRole("button", {
-      name: /register/i,
-    }).click();
+    cy.get('[cy-test="cy-register-button"]').click();
   });
 });

--- a/src/features/auth/Registration.tsx
+++ b/src/features/auth/Registration.tsx
@@ -130,6 +130,7 @@ function Registration() {
               data-test="register-button"
               mb={1}
               disabled={!isValid}
+              cy-test="cy-register-button"
             >
               Register
             </Button>


### PR DESCRIPTION
In this PR was fixed:
1. e2e testing for login, registration and posts.
2. doubling posts: removed registration and login slice, and added auth slice instead. 